### PR TITLE
Update environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,6 @@ dependencies:
   - pip
   - pip:
       - otter-grader==4.3.2
-      - datascience==0.17.6
+      - datascience==0.17.5
       # Allow users to download their home directories
       - jupyter-tree-download


### PR DESCRIPTION
The sp22 notebooks used by cloudbank pilots are relying on datascience 0.17.5 -- 0.17.6 removed the column_labels property from the Table class and replaced it with a labels property.